### PR TITLE
Add experimental backup chains system

### DIFF
--- a/src/main/java/de/melanx/simplebackups/BackupChain.java
+++ b/src/main/java/de/melanx/simplebackups/BackupChain.java
@@ -1,0 +1,150 @@
+package de.melanx.simplebackups;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import de.melanx.simplebackups.config.ExperimentalConfig;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class BackupChain {
+
+    public static final String METADATA_FILE = "metadata.json";
+    private final Path parentFolder;
+    private final Path fullBackup;
+    private final List<Path> children;
+    private final ExperimentalConfig.ExperimentalBackupType experimentalBackupType;
+    private long lastUpdated;
+
+    public BackupChain(Path parentFolder, Path fullBackup, ExperimentalConfig.ExperimentalBackupType experimentalBackupType) {
+        this(parentFolder, fullBackup, new ArrayList<>(), experimentalBackupType, System.currentTimeMillis());
+    }
+
+    public BackupChain(Path parentFolder, Path fullBackup, List<Path> children, ExperimentalConfig.ExperimentalBackupType experimentalBackupType, long lastUpdated) {
+        this.parentFolder = parentFolder;
+        this.fullBackup = fullBackup;
+        this.children = children;
+        this.experimentalBackupType = experimentalBackupType;
+        this.lastUpdated = lastUpdated;
+    }
+
+    public Path getParentFolder() {
+        return this.parentFolder;
+    }
+
+    public Path getFullBackup() {
+        return this.parentFolder.resolve(this.fullBackup);
+    }
+
+    public List<Path> getChildren() {
+        return this.children.stream().map(this.parentFolder::resolve).toList();
+    }
+
+    public ExperimentalConfig.ExperimentalBackupType getBackupType() {
+        return this.experimentalBackupType;
+    }
+
+    public void addChild(Path child) {
+        this.children.add(child);
+    }
+
+    public Path createChild() {
+        int index = this.children.size() + 1;
+        Path child = Path.of("child-" + String.format("%04d", index) + ".zip");
+        this.children.add(child);
+        this.lastUpdated = System.currentTimeMillis();
+        this.writeMetadata();
+
+        return this.parentFolder.resolve(child);
+    }
+
+    public long getLastUpdated() {
+        return this.lastUpdated;
+    }
+
+    public long getFileSize() {
+        try {
+            return Files.walk(this.parentFolder).filter(Files::isRegularFile).mapToLong(path -> {
+                try {
+                    return Files.size(path);
+                } catch (IOException e) {
+                    SimpleBackups.LOGGER.warn("Failed to get size of {}", path, e);
+                    return 0;
+                }
+            }).sum();
+        } catch (IOException e) {
+            SimpleBackups.LOGGER.warn("Failed to get size of {}", this.parentFolder, e);
+            return 0;
+        }
+    }
+
+    public void deleteFiles() {
+        if (!Files.exists(this.parentFolder)) return;
+
+        try {
+            Files.walk(this.parentFolder)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException e) {
+                            SimpleBackups.LOGGER.warn("Failed to delete \"{}\"", path, e);
+                        }
+                    });
+            Files.deleteIfExists(this.parentFolder);
+        } catch (IOException e) {
+            SimpleBackups.LOGGER.warn("Failed to delete directory tree \"{}\"", this.parentFolder, e);
+        }
+    }
+
+    public int getSize() {
+        return this.children.size() + 1;
+    }
+
+    public void writeMetadata() {
+        Path meta = this.parentFolder.resolve(METADATA_FILE);
+        JsonObject json = new JsonObject();
+        json.addProperty("backupType", this.getBackupType().name());
+        json.addProperty("fullBackup", this.fullBackup.toString());
+        JsonArray children = new JsonArray();
+        for (Path child : this.children) {
+            children.add(child.toString());
+        }
+        json.add("children", children);
+        json.addProperty("lastUpdated", this.lastUpdated);
+        try {
+            Files.writeString(meta, json.toString());
+        } catch (IOException e) {
+            SimpleBackups.LOGGER.warn("Failed to write metadata to {}", meta, e);
+        }
+    }
+
+    @Nullable
+    public static BackupChain readMetadata(Path chainDir) {
+        Path meta = chainDir.resolve(METADATA_FILE);
+
+        try {
+            JsonObject json = new Gson().fromJson(Files.newBufferedReader(meta), JsonObject.class);
+
+            Path fullBackup = Path.of(json.get("fullBackup").getAsString());
+            List<Path> children = new ArrayList<>();
+            for (JsonElement child : json.getAsJsonArray("children")) {
+                children.add(Path.of(child.getAsString()));
+            }
+            ExperimentalConfig.ExperimentalBackupType backupType = ExperimentalConfig.ExperimentalBackupType.valueOf(json.get("backupType").getAsString());
+            long lastUpdated = json.get("lastUpdated").getAsLong();
+
+            return new BackupChain(chainDir, fullBackup, children, backupType, lastUpdated);
+        } catch (IOException e) {
+            SimpleBackups.LOGGER.warn("Failed to read metadata from {}", meta, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/de/melanx/simplebackups/BackupChainManager.java
+++ b/src/main/java/de/melanx/simplebackups/BackupChainManager.java
@@ -1,0 +1,102 @@
+package de.melanx.simplebackups;
+
+import de.melanx.simplebackups.config.CommonConfig;
+import de.melanx.simplebackups.config.ExperimentalConfig;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class BackupChainManager {
+
+    private static final Map<String, BackupChainManager> INSTANCES = new HashMap<>();
+    private final List<BackupChain> chains = new ArrayList<>();
+    private final String levelId;
+
+    private BackupChainManager(String levelId) {
+        this.levelId = levelId;
+    }
+
+    public static BackupChainManager get(String levelId) {
+        return INSTANCES.computeIfAbsent(levelId, str -> {
+            BackupChainManager manager = new BackupChainManager(str);
+            manager.reloadAllChains();
+            return manager;
+        });
+    }
+
+    public void addChain(BackupChain chain) {
+        try {
+            Files.createDirectories(chain.getParentFolder());
+            chain.writeMetadata();
+            this.chains.add(chain);
+            this.chains.sort(Comparator.comparingLong(BackupChain::getLastUpdated));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create new backup chain", e);
+        }
+    }
+
+    public BackupChain createChain(String baseName) {
+        Path chainDir = CommonConfig.getOutputPath(this.levelId).resolve(baseName);
+        Path backupFilePath = Paths.get("full.zip");
+        BackupChain backupChain = new BackupChain(chainDir, backupFilePath, ExperimentalConfig.backupType());
+
+        this.addChain(backupChain);
+        return backupChain;
+    }
+
+    public void removeChain(BackupChain chain) {
+        this.chains.remove(chain);
+        chain.deleteFiles();
+    }
+
+    public List<BackupChain> getChains() {
+        return new LinkedList<>(this.chains);
+    }
+
+    public BackupChain getFirstChain() {
+        return this.chains.getFirst();
+    }
+
+    @Nullable
+    public BackupChain getLatestChain() {
+        if (this.chains.isEmpty()) {
+            return null;
+        }
+
+        return this.chains.getLast();
+    }
+
+    public long getFileSize() {
+        return this.chains.stream().mapToLong(BackupChain::getFileSize).sum();
+    }
+
+    public void reloadAllChains() {
+        List<BackupChain> chains = new ArrayList<>();
+        try {
+            Path outputPath = CommonConfig.getOutputPath(this.levelId);
+            if (!Files.exists(outputPath)) {
+                this.chains.clear();
+                return;
+            }
+
+            Files.walk(outputPath).filter(Files::isDirectory).forEach(dir -> {
+                if (dir.resolve(BackupChain.METADATA_FILE).toFile().exists()) {
+                    BackupChain backupChain = BackupChain.readMetadata(dir);
+                    if (backupChain != null) {
+                        chains.add(backupChain);
+                    }
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to reload backup chains for " + this.levelId, e);
+        }
+
+        this.chains.clear();
+        this.chains.addAll(chains);
+        this.chains.sort(Comparator.comparingLong(BackupChain::getLastUpdated));
+    }
+}

--- a/src/main/java/de/melanx/simplebackups/BackupThread.java
+++ b/src/main/java/de/melanx/simplebackups/BackupThread.java
@@ -4,6 +4,7 @@ import de.melanx.simplebackups.compat.CherishedWorldsCompat;
 import de.melanx.simplebackups.compat.Mc2DiscordCompat;
 import de.melanx.simplebackups.config.BackupType;
 import de.melanx.simplebackups.config.CommonConfig;
+import de.melanx.simplebackups.config.ExperimentalConfig;
 import de.melanx.simplebackups.config.ServerConfig;
 import de.melanx.simplebackups.exception.NotEnoughDiskSpaceException;
 import de.melanx.simplebackups.network.Pause;
@@ -35,6 +36,7 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -57,6 +59,8 @@ public class BackupThread extends Thread {
     private final LevelStorageSource.LevelStorageAccess storageSource;
     private final Path backupPath;
     private final Set<Path> errors = new HashSet<>();
+    private final BackupChainManager manager;
+    private boolean forceFullBackup = false;
 
     private BackupThread(@Nonnull MinecraftServer server, boolean quiet, BackupData backupData) {
         this.server = server;
@@ -66,12 +70,15 @@ public class BackupThread extends Thread {
             this.lastSaved = 0;
             this.fullBackup = true;
         } else {
+            long now = CommonConfig.useTickCounter() ? server.overworld().getGameTime() : System.currentTimeMillis();
             this.lastSaved = CommonConfig.backupType() == BackupType.MODIFIED_SINCE_LAST ? backupData.getLastSaved() : backupData.getLastFullBackup();
-            this.fullBackup = CommonConfig.backupType() == BackupType.FULL_BACKUPS || (CommonConfig.useTickCounter() ? server.overworld().getGameTime() : System.currentTimeMillis()) - CommonConfig.getFullBackupTimer() > backupData.getLastFullBackup();
+            this.fullBackup = CommonConfig.backupType() == BackupType.FULL_BACKUPS || (now - CommonConfig.getFullBackupTimer()) > backupData.getLastFullBackup();
         }
         this.setName("SimpleBackups");
         this.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(LOGGER));
-        this.backupPath = CommonConfig.getOutputPath(this.storageSource.getLevelId());
+        String levelId = this.storageSource.getLevelId();
+        this.backupPath = CommonConfig.getOutputPath(levelId);
+        this.manager = ExperimentalConfig.isEnabled() ? BackupChainManager.get(levelId) : null;
     }
 
     public static boolean tryCreateBackup(MinecraftServer server) {
@@ -81,7 +88,7 @@ public class BackupThread extends Thread {
             thread.start();
             long currentTime = CommonConfig.useTickCounter() ? server.overworld().getGameTime() : System.currentTimeMillis();
             backupData.updateSaveTime(currentTime);
-            if (thread.fullBackup) {
+            if (thread.createFullBackup()) {
                 backupData.updateFullBackupTime(currentTime);
             }
 
@@ -118,6 +125,11 @@ public class BackupThread extends Thread {
     }
 
     public void deleteFiles() {
+        if (ExperimentalConfig.isEnabled()) {
+            this.deleteFilesExperimental();
+            return;
+        }
+
         File backups = this.backupPath.toFile();
         if (backups.isDirectory()) {
             List<File> files = new ArrayList<>(Arrays.stream(Objects.requireNonNull(backups.listFiles())).filter(File::isFile).toList());
@@ -137,6 +149,11 @@ public class BackupThread extends Thread {
 
     public void saveStorageSize() {
         try {
+            if (ExperimentalConfig.isEnabled()) {
+                this.saveStorageSizeExperimental();
+                return;
+            }
+
             while (this.getOutputFolderSize() > CommonConfig.getMaxDiskSize()) {
                 File[] files = this.backupPath.toFile().listFiles();
                 if (Objects.requireNonNull(files).length == 1) {
@@ -151,8 +168,35 @@ public class BackupThread extends Thread {
                     LOGGER.info("Successfully deleted \"{}\"", name);
                 }
             }
-        } catch (NullPointerException | IOException e) {
+        } catch (NullPointerException e) {
             LOGGER.error("Cannot delete old files to save disk space", e);
+        }
+    }
+
+    private void deleteFilesExperimental() {
+        if (this.manager.getChains().isEmpty()) {
+            return;
+        }
+
+        int maxChains = CommonConfig.getBackupsToKeep();
+        while (this.manager.getChains().size() > maxChains) {
+            BackupChain chain = this.manager.getFirstChain();
+            LOGGER.info("Deleting backup chain directory \"{}\"", chain.getParentFolder());
+            this.manager.removeChain(chain);
+        }
+    }
+
+    private void saveStorageSizeExperimental() {
+        while (this.manager.getFileSize() > CommonConfig.getMaxDiskSize()) {
+            List<BackupChain> chains = this.manager.getChains();
+            if (chains.size() <= 1) {
+                LOGGER.error("Cannot delete old chains to save disk space. Only one chain directory left!");
+                return;
+            }
+
+            BackupChain victim = chains.getFirst();
+            LOGGER.info("Deleting backup chain directory \"{}\" to save disk space", victim.getParentFolder());
+            this.manager.removeChain(victim);
         }
     }
 
@@ -209,26 +253,54 @@ public class BackupThread extends Thread {
     }
 
     private Path getBackupFilePath() throws IOException {
+        if (ExperimentalConfig.isEnabled()) {
+            return this.getChainBackupFilePath();
+        }
+
         String fileName = this.storageSource.getLevelId() + "_" + LocalDateTime.now().format(FORMATTER);
-        Path path = CommonConfig.getOutputPath(this.storageSource.getLevelId());
+        Path path = this.backupPath;
 
         Files.createDirectories(Files.exists(path) ? path.toRealPath() : path);
 
         return path.resolve(FileUtil.findAvailableName(path, fileName, ".zip"));
     }
 
-    private long getOutputFolderSize() throws IOException {
-        File[] files = this.backupPath.toFile().listFiles();
-        long size = 0;
-        try {
-            for (File file : Objects.requireNonNull(files)) {
-                size += Files.size(file.toPath());
-            }
-        } catch (NullPointerException e) {
+    private Path getChainBackupFilePath() throws IOException {
+        Path worldBackupDir = this.backupPath;
+        Files.createDirectories(Files.exists(worldBackupDir) ? worldBackupDir.toRealPath() : worldBackupDir);
+        String baseName = LocalDateTime.now().format(FORMATTER);
+        BackupChain latestChain = this.manager.getLatestChain();
+
+        if (this.fullBackup || latestChain == null) {
+            this.forceFullBackup = true;
+            BackupChain chain = this.manager.createChain(baseName);
+            return chain.getFullBackup();
+        }
+
+        return latestChain.createChild();
+    }
+
+    private long getOutputFolderSize() {
+        if (!Files.exists(this.backupPath)) {
             return 0;
         }
 
-        return size;
+        try (Stream<Path> stream = Files.walk(this.backupPath)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .mapToLong(path -> {
+                        try {
+                            return Files.size(path);
+                        } catch (IOException e) {
+                            LOGGER.warn("Failed to get size of {}", path, e);
+                            return 0L;
+                        }
+                    })
+                    .sum();
+        } catch (IOException e) {
+            LOGGER.warn("Failed to get size of backup folder", e);
+            return 0L;
+        }
     }
 
     private void broadcast(String message, Style style, Object... parameters) {
@@ -300,7 +372,7 @@ public class BackupThread extends Thread {
                     }
 
                     long lastModified = file.toFile().lastModified();
-                    if (BackupThread.this.fullBackup || lastModified - BackupThread.this.lastSaved > 0) {
+                    if (BackupThread.this.createFullBackup() || lastModified - BackupThread.this.lastSaved > 0) {
                         if (fileStore.getUsableSpace() - attrs.size() - BACKUP_BUFFER_SIZE < 0L) {
                             throw new NotEnoughDiskSpaceException("Not enough space on disk to create backup");
                         }
@@ -350,6 +422,10 @@ public class BackupThread extends Thread {
         }
 
         return new BackupResult(outputFile, Files.size(outputFile));
+    }
+
+    private boolean createFullBackup() {
+        return this.fullBackup || this.forceFullBackup;
     }
 
     private record BackupResult(Path outputFile, long fileSize) {}

--- a/src/main/java/de/melanx/simplebackups/SimpleBackups.java
+++ b/src/main/java/de/melanx/simplebackups/SimpleBackups.java
@@ -2,6 +2,7 @@ package de.melanx.simplebackups;
 
 import de.melanx.simplebackups.client.ClientInit;
 import de.melanx.simplebackups.config.CommonConfig;
+import de.melanx.simplebackups.config.ExperimentalConfig;
 import de.melanx.simplebackups.config.ServerConfig;
 import de.melanx.simplebackups.network.Pause;
 import net.neoforged.api.distmarker.Dist;
@@ -24,6 +25,7 @@ public class SimpleBackups {
 
     public SimpleBackups(IEventBus modEventBus, ModContainer modContainer, Dist dist) {
         modContainer.registerConfig(ModConfig.Type.COMMON, CommonConfig.CONFIG);
+        modContainer.registerConfig(ModConfig.Type.COMMON, ExperimentalConfig.CONFIG, "simplebackups-common-experimental.toml");
         modContainer.registerConfig(ModConfig.Type.SERVER, ServerConfig.CONFIG);
         NeoForge.EVENT_BUS.register(new EventListener());
         modEventBus.addListener(this::setup);

--- a/src/main/java/de/melanx/simplebackups/commands/MergeCommand.java
+++ b/src/main/java/de/melanx/simplebackups/commands/MergeCommand.java
@@ -1,42 +1,48 @@
 package de.melanx.simplebackups.commands;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import de.melanx.simplebackups.BackupChain;
+import de.melanx.simplebackups.BackupChainManager;
 import de.melanx.simplebackups.BackupData;
+import de.melanx.simplebackups.SimpleBackups;
 import de.melanx.simplebackups.config.BackupType;
 import de.melanx.simplebackups.config.CommonConfig;
+import de.melanx.simplebackups.config.ExperimentalConfig;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
 
-import javax.annotation.Nonnull;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 public class MergeCommand implements Command<CommandSourceStack> {
 
-
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         return Commands.literal("mergeBackups")
-                .executes(new MergeCommand());
+                .executes(new MergeCommand())
+                .then(Commands.argument("chain", StringArgumentType.string()).suggests((stack, builder) -> {
+                            String levelId = stack.getSource().getServer().storageSource.getLevelId();
+                            BackupChainManager manager = BackupChainManager.get(levelId);
+
+                            return SharedSuggestionProvider.suggest(manager.getChains().stream().map(chain -> chain.getParentFolder().getFileName().toString()), builder);
+                        })
+                        .executes(new MergeCommand())
+                        .requires(stack -> ExperimentalConfig.isEnabled()));
     }
 
     @Override
@@ -53,12 +59,49 @@ public class MergeCommand implements Command<CommandSourceStack> {
             throw new SimpleCommandExceptionType(Component.translatable("simplebackups.commands.is_merging")).create();
         }
 
-        MergingThread mergingThread = new MergingThread(commandContext);
+        if (ExperimentalConfig.isEnabled()) {
+            try {
+                String chainName = commandContext.getArgument("chain", String.class);
+                BackupChainManager manager = BackupChainManager.get(commandContext.getSource().getServer().storageSource.getLevelId());
+                List<Path> zipFiles = new ArrayList<>();
+                for (BackupChain chain : manager.getChains()) {
+                    if (chain.getParentFolder().getFileName().toString().equals(chainName)) {
+                        ExperimentalConfig.ExperimentalBackupType backupType = chain.getBackupType();
+                        switch(backupType) {
+                            case FULL_BACKUPS ->
+                                    throw new SimpleCommandExceptionType(Component.translatable("simplebackups.commands.only_modified")).create();
+                            case INCREMENTAL -> {
+                                zipFiles.add(chain.getFullBackup());
+                                zipFiles.addAll(chain.getChildren());
+                            }
+                            case DIFFERENTIAL -> {
+                                zipFiles.add(chain.getFullBackup());
+                                zipFiles.add(chain.getChildren().getLast());
+                            }
+                        }
+
+                        MergingThread mergingThread = new MergingThread(zipFiles, commandContext);
+                        data.startMerging();
+                        mergingThread.start();
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                SimpleBackups.LOGGER.error("Invalid chain name: {}", commandContext.getArgument("chain", String.class), e);
+                data.stopMerging();
+                return 0;
+            }
+
+            data.stopMerging();
+            return 1;
+        }
+
         try {
+            List<Path> backupSources = Files.list(CommonConfig.getOutputPath(commandContext.getSource().getServer().storageSource.getLevelId())).toList();
+            MergingThread mergingThread = new MergingThread(backupSources, commandContext);
             data.startMerging();
             mergingThread.start();
         } catch (Exception e) {
-            e.printStackTrace();
+            SimpleBackups.LOGGER.error("Failed to merge backups", e);
             data.stopMerging();
             return 0;
         }
@@ -69,33 +112,32 @@ public class MergeCommand implements Command<CommandSourceStack> {
 
     private static class MergingThread extends Thread {
 
+        private final List<Path> backupSources;
         private final CommandContext<CommandSourceStack> commandContext;
 
-        public MergingThread(CommandContext<CommandSourceStack> commandContext) {
+        public MergingThread(List<Path> backupSources, CommandContext<CommandSourceStack> commandContext) {
+            this.backupSources = backupSources;
             this.commandContext = commandContext;
         }
 
         @Override
         public void run() {
-            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("merged_backup-" + UUID.randomUUID() + ".zip"))) {
-                Map<String, Path> zipFiles = new HashMap<>();
+            Path mainBackupsDir = CommonConfig.getOutputPath("ignore").getParent();
+            Path mergedBackupPath = mainBackupsDir.resolve("merged_backup-" + UUID.randomUUID() + ".zip");
+            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(mergedBackupPath.toFile()))) {
+                Map<String, Path> dataFiles = new HashMap<>();
 
                 // Walk the file tree of the output path
-                Files.walkFileTree(CommonConfig.getOutputPath(this.commandContext.getSource().getServer().storageSource.getLevelId()), new SimpleFileVisitor<>() {
-                    @Nonnull
-                    @Override
-                    public FileVisitResult visitFile(Path file, @Nonnull BasicFileAttributes attrs) throws IOException {
-                        MergingThread.this.processFile(file, zipFiles);
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
+                for (Path backupSource : this.backupSources) {
+                    this.processFile(backupSource, dataFiles);
+                }
 
                 // Write the merged zip file
-                this.writeMergedZipFile(zos, zipFiles);
+                this.writeMergedZipFile(zos, dataFiles);
             } catch (IOException e) {
                 throw new IllegalStateException("Error while processing backups", e);
             } finally {
-                this.commandContext.getSource().sendSuccess(() -> Component.translatable("simplebackups.commands.finished"), false);
+                this.commandContext.getSource().sendSuccess(() -> Component.translatable("simplebackups.commands.finished", mainBackupsDir.getParent().relativize(mergedBackupPath).toString()), false);
             }
         }
 

--- a/src/main/java/de/melanx/simplebackups/config/CommonConfig.java
+++ b/src/main/java/de/melanx/simplebackups/config/CommonConfig.java
@@ -16,6 +16,7 @@ public class CommonConfig {
     public static final ModConfigSpec CONFIG;
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
     private static final String DEFAULT_DISK_SIZE = "25 GB";
+    private static final String EXPERIMENTAL_NOTE = "Experimental setting available, look at 'simplebackups-common-experimental.toml' to help testing";
 
     static {
         init(BUILDER);
@@ -47,13 +48,17 @@ public class CommonConfig {
     public static void init(ModConfigSpec.Builder builder) {
         enabled = builder.comment("If set false, no backups are being made.")
                 .define("enabled", true);
-        backupType = builder.comment("Defines the backup type.\n- FULL_BACKUPS - always creates full backups\n- MODIFIED_SINCE_LAST - only saves the files which changed since last (partial) backup\n- MODIFIED_SINCE_FULL - saves all files which changed after the last full backup")
+        backupType = builder.comment(EXPERIMENTAL_NOTE,
+                        "Defines the backup type.",
+                        "- FULL_BACKUPS - always creates full backups",
+                        "- MODIFIED_SINCE_LAST - only saves the files which changed since last (partial) backup",
+                        "- MODIFIED_SINCE_FULL - saves all files which changed after the last full backup")
                 .defineEnum("backupType", BackupType.FULL_BACKUPS);
         saveAll = builder.comment("Should a save-all be forced before backup?")
                 .define("saveAll", true);
         fullBackupTimer = builder.comment("How often should a full backup be created if only modified files should be saved? This creates a full backup when x minutes are over and the next backup needs to be done. Once a year is default.")
                 .defineInRange("fullBackupTimer", 525960, 1, 5259600);
-        backupsToKeep = builder.comment("The max amount of backup files to keep.")
+        backupsToKeep = builder.comment(EXPERIMENTAL_NOTE, "The max amount of backup files to keep.")
                 .defineInRange("backupsToKeep", 10, 1, Short.MAX_VALUE);
         timer = builder.comment("The time between two backups in minutes", "5 = each 5 minutes", "60 = each hour", "1440 = each day")
                 .defineInRange("timer", 120, 1, Short.MAX_VALUE);
@@ -118,7 +123,7 @@ public class CommonConfig {
     }
 
     public static int getBackupsToKeep() {
-        return backupsToKeep.get();
+        return ExperimentalConfig.isEnabled() ? ExperimentalConfig.backupChainsToKeep() : backupsToKeep.get();
     }
 
     // converts config value from milliseconds to minutes
@@ -159,7 +164,7 @@ public class CommonConfig {
     }
 
     public static BackupType backupType() {
-        return backupType.get();
+        return ExperimentalConfig.isEnabled() ? ExperimentalConfig.backupType().asLegacyType() : backupType.get();
     }
 
     public static boolean saveAll() {

--- a/src/main/java/de/melanx/simplebackups/config/ExperimentalConfig.java
+++ b/src/main/java/de/melanx/simplebackups/config/ExperimentalConfig.java
@@ -1,0 +1,58 @@
+package de.melanx.simplebackups.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public class ExperimentalConfig {
+
+    public static final ModConfigSpec CONFIG;
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        init(BUILDER);
+        CONFIG = BUILDER.build();
+    }
+
+    private static ModConfigSpec.BooleanValue enabled;
+    private static ModConfigSpec.EnumValue<ExperimentalBackupType> backupType;
+    private static ModConfigSpec.IntValue backupChainsToKeep;
+
+    public static void init(ModConfigSpec.Builder builder) {
+        enabled = builder.comment("Only enable if you want to test the experimental backup system.")
+                .define("enabled", false);
+        backupType = builder.comment("Defines the backup type.",
+                        "- FULL_BACKUPS - every backup is a full backup.",
+                        "- INCREMENTAL  - backup only files changed since the last backup",
+                        "- DIFFERENTIAL - backup only files changed since the last full backup")
+                .defineEnum("backupType", ExperimentalBackupType.INCREMENTAL);
+        backupChainsToKeep = builder.comment("The max amount of backup chains to keep.")
+                .defineInRange("backupChainsToKeep", 10, 1, Short.MAX_VALUE);
+    }
+
+    public static boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public static ExperimentalBackupType backupType() {
+        return backupType.get();
+    }
+
+    public static int backupChainsToKeep() {
+        return backupChainsToKeep.get();
+    }
+
+    public enum ExperimentalBackupType {
+        FULL_BACKUPS(BackupType.FULL_BACKUPS),
+        INCREMENTAL(BackupType.MODIFIED_SINCE_LAST),
+        DIFFERENTIAL(BackupType.MODIFIED_SINCE_FULL);
+
+        private final BackupType backupType;
+
+        ExperimentalBackupType(BackupType backupType) {
+            this.backupType = backupType;
+        }
+
+        public BackupType asLegacyType() {
+            return this.backupType;
+        }
+    }
+}

--- a/src/main/resources/assets/simplebackups/lang/de_de.json
+++ b/src/main/resources/assets/simplebackups/lang/de_de.json
@@ -7,9 +7,11 @@
   "simplebackups.backups_paused": "Backups pausiert",
   "simplebackups.commands.only_modified": "Es werden nicht nur veränderte Dateien gesichert, prüfe deine Konfigurationsdatei",
   "simplebackups.commands.is_merging": "Ein Zusammenführungsvorgang ist bereits im Gange",
-  "simplebackups.commands.finished": "Zusammenführen der Backups erfolgreich abgeschlossen",
+  "simplebackups.commands.finished": "Zusammenführen der Backups erfolgreich abgeschlossen unter %s",
   "simplebackups.not_enough_space": "Nicht genug Speicherplatz auf dem Datenträger, um das Backup zu erstellen. Vorgang abgebrochen!",
 
+  "simplebackups.configuration.section.simplebackups.common.experimental.toml": "Experimentelle Einstellungen",
+  "simplebackups.configuration.backupChainsToKeep": "Backups-Ketten zum Behalten",
   "simplebackups.configuration.noPlayerBackups": "Backups ohne Spieler",
   "simplebackups.configuration.messagesForEveryone": "Nachrichten für alle",
   "simplebackups.configuration.createSubDirs": "Unterverzeichnisse erstellen",

--- a/src/main/resources/assets/simplebackups/lang/en_us.json
+++ b/src/main/resources/assets/simplebackups/lang/en_us.json
@@ -7,9 +7,11 @@
   "simplebackups.backups_paused": "Backups paused",
   "simplebackups.commands.only_modified": "Not only modified files are being backed up, please check your configuration file",
   "simplebackups.commands.is_merging": "A merge operation is already in progress",
-  "simplebackups.commands.finished": "Merging backups completed successfully",
+  "simplebackups.commands.finished": "Merging backups completed successfully at %s",
   "simplebackups.not_enough_space": "Not enough space on disk to create backup. Aborted!",
 
+  "simplebackups.configuration.section.simplebackups.common.experimental.toml": "Experimental settings",
+  "simplebackups.configuration.backupChainsToKeep": "Backup Chains to keep",
   "simplebackups.configuration.noPlayerBackups": "Backups without Players",
   "simplebackups.configuration.messagesForEveryone": "Messages for Everyone",
   "simplebackups.configuration.createSubDirs": "Create subdirectories",

--- a/src/main/resources/assets/simplebackups/lang/ja_jp.json
+++ b/src/main/resources/assets/simplebackups/lang/ja_jp.json
@@ -4,5 +4,5 @@
   "simplebackups.backups_paused": "バックアップ一時停止",
   "simplebackups.commands.only_modified": "変更されたファイルだけがバックアップされるわけではありません。コンフィグファイルを確認してください。",
   "simplebackups.commands.is_merging": "マージ操作がすでに進行中です。",
-  "simplebackups.commands.finished": "バックアップのマージが正常に完了"
+  "simplebackups.commands.finished": "バックアップのマージが正常に完了 %s"
 }

--- a/src/main/resources/assets/simplebackups/lang/pt_br.json
+++ b/src/main/resources/assets/simplebackups/lang/pt_br.json
@@ -4,5 +4,5 @@
     "simplebackups.backups_paused": "Backups pausados",
     "simplebackups.commands.only_modified": "Não apenas arquivos modificados estão sendo salvos, por favor, verifique seu arquivo de configuração",
     "simplebackups.commands.is_merging": "Uma operação de mesclagem já está em andamento",
-    "simplebackups.commands.finished": "Mesclagem de backups concluída com sucesso"
+  "simplebackups.commands.finished": "Mesclagem de backups concluída com sucesso %s"
 }

--- a/src/main/resources/assets/simplebackups/lang/ru_ru.json
+++ b/src/main/resources/assets/simplebackups/lang/ru_ru.json
@@ -4,7 +4,7 @@
   "simplebackups.backups_paused": "Резервное копирование приостановлено",
   "simplebackups.commands.only_modified": "Сохраняются не только изменённые файлы, пожалуйста, проверьте ваш файл конфигурации",
   "simplebackups.commands.is_merging": "Операция слияния уже выполняется",
-  "simplebackups.commands.finished": "Слияние резервных копий успешно завершено",
+  "simplebackups.commands.finished": "Слияние резервных копий успешно завершено %s",
 
   "simplebackups.configuration.noPlayerBackups": "Резервные копии без игроков",
   "simplebackups.configuration.messagesForEveryone": "Сообщения для всех игроков",

--- a/src/main/resources/assets/simplebackups/lang/tr_tr.json
+++ b/src/main/resources/assets/simplebackups/lang/tr_tr.json
@@ -4,5 +4,5 @@
   "simplebackups.backups_paused": "Yedeklemeler duraklatıldı",
   "simplebackups.commands.only_modified": "Yalnızca değiştirilen dosyalar yedeklenmiyor, lütfen yapılandırma dosyanızı kontrol edin",
   "simplebackups.commands.is_merging": "Bir birleştirme işlemi zaten devam ediyor",
-  "simplebackups.commands.finished": "Yedeklerin birleştirilmesi başarıyla tamamlandı"
+  "simplebackups.commands.finished": "Yedeklerin birleştirilmesi başarıyla tamamlandı %s"
 }

--- a/src/main/resources/assets/simplebackups/lang/zh_cn.json
+++ b/src/main/resources/assets/simplebackups/lang/zh_cn.json
@@ -4,5 +4,5 @@
   "simplebackups.backups_paused": "备份中止",
   "simplebackups.commands.only_modified": "不只备份了修改后的文件，请检查你的配置文件",
   "simplebackups.commands.is_merging": "已有一个合并操作正在执行",
-  "simplebackups.commands.finished": "合并备份成功"
+  "simplebackups.commands.finished": "合并备份成功 %s"
 }

--- a/src/main/resources/assets/simplebackups/lang/zh_tw.json
+++ b/src/main/resources/assets/simplebackups/lang/zh_tw.json
@@ -4,5 +4,5 @@
   "simplebackups.backups_paused": "備份已暫停",
   "simplebackups.commands.only_modified": "目前備份的對象不只是已修改的檔案，請檢查你的設定檔",
   "simplebackups.commands.is_merging": "合併操作已在進行中",
-  "simplebackups.commands.finished": "備份合併已成功完成"
+  "simplebackups.commands.finished": "備份合併已成功完成 %s"
 }


### PR DESCRIPTION
This pull request adds a similar system as #42 to resolve the issue #39. However, this is only an experimental setting. Experimental settings can be enabled by using the new config file `simplebackups-common-experimental.toml`. These settings will override the normal settings for `backupType` and `backupsToKeep` if enabled. Additionally, it changes how backups are being stored. It looks like this now:

```sh
world_name
├── 2025-11-29_20-37-59
│   ├── chain.meta
│   ├── child-0001.zip
│   └── full.zip
├── 2025-11-29_20-40-01
│   ├── chain.meta
│   └── full.zip
├── 2025-11-30_11-43-40
│   ├── full.zip
│   └── metadata.json
├── 2025-11-30_12-00-55
│   ├── child-0003.zip
│   ├── child-0004.zip
│   ├── full.zip
│   └── metadata.json
├── 2025-11-30_12-05-58
│   ├── child-0001.zip
│   ├── child-0002.zip
│   ├── child-0003.zip
│   ├── child-0004.zip
│   ├── full.zip
│   └── metadata.json
```

By naming the files `full.zip` and `child-%04d.zip`, it also resolves issue #58. For now, I will only add this to 1.21.9+ because of maybe breaking behavior. I'll backport it to at least 1.21.1 after a while. I hope to release the 1.21.11 version only with the experimental setting and remove the old behavior. We'll see :)

> [!NOTE]
> I'm happy about every feedback regarding this experimental setting. 
> If you use it and it works, tell me!
> If you use it and it doesn't work, tell me! 


Closes #39 
Closes #58 
