### PR TITLE
Add option to create `N` backups when there are no players

### DIFF
--- a/src/main/java/de/melanx/simplebackups/BackupData.java
+++ b/src/main/java/de/melanx/simplebackups/BackupData.java
@@ -15,6 +15,7 @@ public class BackupData extends SavedData {
     private boolean paused;
     private boolean merging;
     private boolean usesTickCounter;
+    private int backupsSinceLastPlayerJoined;
 
     private BackupData() {
         // use BackupData.get
@@ -28,6 +29,7 @@ public class BackupData extends SavedData {
         nbt.putBoolean("paused", this.paused);
         nbt.putBoolean("merging", this.merging);
         nbt.putBoolean("usesTickCounter", this.usesTickCounter);
+        nbt.putInt("backupsSinceLastPlayerJoined", this.backupsSinceLastPlayerJoined);
         return nbt;
     }
 
@@ -45,6 +47,7 @@ public class BackupData extends SavedData {
         this.paused = nbt.getBoolean("paused");
         this.merging = nbt.getBoolean("merging");
         this.usesTickCounter = nbt.getBoolean("usesTickCounter");
+        this.backupsSinceLastPlayerJoined = nbt.getInt("backupsSinceLastPlayerJoined");
         return this;
     }
 
@@ -72,6 +75,24 @@ public class BackupData extends SavedData {
 
     public void updateFullBackupTime(long time) {
         this.lastFullBackup = time;
+        this.setDirty();
+    }
+
+    public int backupsSinceLastPlayerJoined() {
+        return this.backupsSinceLastPlayerJoined;
+    }
+
+    public void incrementBackupsSinceLastPlayerJoined() {
+        this.backupsSinceLastPlayerJoined++;
+        this.setDirty();
+    }
+
+    public void resetBackupsSinceLastPlayerJoined() {
+        if (this.backupsSinceLastPlayerJoined == 0) {
+            return;
+        }
+
+        this.backupsSinceLastPlayerJoined = 0;
         this.setDirty();
     }
 

--- a/src/main/java/de/melanx/simplebackups/BackupThread.java
+++ b/src/main/java/de/melanx/simplebackups/BackupThread.java
@@ -108,15 +108,17 @@ public class BackupThread extends Thread {
             return false;
         }
 
+        boolean arePlayersOnline = !server.getPlayerList().getPlayers().isEmpty();
+
         if (CommonConfig.useTickCounter()) {
             long gameTime = server.overworld().getGameTime();
             long lastSaved = backupData.getLastSaved();
             // convert timer from minutes into ticks
-            long timer = CommonConfig.getTimer() * 20 * 60;
+            long timer = CommonConfig.getTimer(arePlayersOnline) * 20 * 60;
             return gameTime - lastSaved >= timer;
         }
 
-        return System.currentTimeMillis() - CommonConfig.getTimer() > backupData.getLastSaved();
+        return System.currentTimeMillis() - CommonConfig.getTimer(arePlayersOnline) > backupData.getLastSaved();
     }
 
     public static void createBackup(MinecraftServer server, boolean quiet) {

--- a/src/main/java/de/melanx/simplebackups/EventListener.java
+++ b/src/main/java/de/melanx/simplebackups/EventListener.java
@@ -36,12 +36,17 @@ public class EventListener {
                 && level.getGameTime() % 20 == 0 && level == level.getServer().overworld()) {
             EventListener.checkForTickCounterConfigUpdate(event.getLevel().getServer());
 
-            if (!level.getServer().getPlayerList().getPlayers().isEmpty() || this.doBackup || CommonConfig.doNoPlayerBackups()) {
-                this.doBackup = false;
+            boolean arePlayersOnline = !level.getServer().getPlayerList().getPlayers().isEmpty();
+            if (arePlayersOnline || this.doBackup || CommonConfig.doNoPlayerBackups()) {
+                BackupData backupData = BackupData.get(level);
+                this.doBackup = !(CommonConfig.noPlayerBackupCount() == 0 || backupData.backupsSinceLastPlayerJoined() >= CommonConfig.noPlayerBackupCount());
 
                 boolean done = BackupThread.tryCreateBackup(level.getServer());
                 if (done) {
                     SimpleBackups.LOGGER.info("Backup done.");
+                    if (!arePlayersOnline) {
+                        backupData.incrementBackupsSinceLastPlayerJoined();
+                    }
                 }
             }
         }
@@ -50,6 +55,7 @@ public class EventListener {
     @SubscribeEvent
     public void onPlayerConnect(PlayerEvent.PlayerLoggedInEvent event) {
         ServerPlayer player = (ServerPlayer) event.getEntity();
+        BackupData.get(player.serverLevel()).resetBackupsSinceLastPlayerJoined();
         //noinspection UnstableApiUsage
         if (CommonConfig.isEnabled() && event.getEntity().getServer() != null && NetworkRegistry.hasChannel(player.connection.connection, null, Pause.ID)) {
             PacketDistributor.sendToPlayer(player, new Pause(BackupData.get(event.getEntity().getServer()).isPaused()));
@@ -75,7 +81,7 @@ public class EventListener {
             backupData.setUsesTickCounter(usesTickCounter);
 
             long lastTimeSaved = backupData.getLastSaved();
-            long commonConfigTimer = CommonConfig.getTimer();
+            long commonConfigTimer = CommonConfig.getTimer(true);
 
             SimpleBackups.LOGGER.info("Initial lastTimeSaved: {}", lastTimeSaved);
             SimpleBackups.LOGGER.info("Config timer in minutes: {}", commonConfigTimer);

--- a/src/main/java/de/melanx/simplebackups/EventListener.java
+++ b/src/main/java/de/melanx/simplebackups/EventListener.java
@@ -67,7 +67,7 @@ public class EventListener {
         if (event.getEntity() instanceof ServerPlayer player) {
             //noinspection ConstantConditions
             if (player.getServer().getPlayerList().getPlayers().isEmpty()) {
-                this.doBackup = true;
+                this.doBackup = !(CommonConfig.noPlayerBackupCount() == 0 || BackupData.get(player.serverLevel()).backupsSinceLastPlayerJoined() >= CommonConfig.noPlayerBackupCount());
             }
         }
     }

--- a/src/main/java/de/melanx/simplebackups/config/CommonConfig.java
+++ b/src/main/java/de/melanx/simplebackups/config/CommonConfig.java
@@ -34,6 +34,8 @@ public class CommonConfig {
     private static ModConfigSpec.ConfigValue<String> maxDiskSize;
     private static ModConfigSpec.ConfigValue<String> outputPath;
     private static ModConfigSpec.BooleanValue noPlayerBackups;
+    private static ModConfigSpec.IntValue noPlayerBackupCount;
+    private static ModConfigSpec.IntValue noPlayerBackupTimer;
     private static ModConfigSpec.BooleanValue createSubDirs;
     private static ModConfigSpec.BooleanValue useTickCounter;
     private static ModConfigSpec.BooleanValue collectErrors;
@@ -77,6 +79,10 @@ public class CommonConfig {
                 .define("outputPath", "simplebackups");
         noPlayerBackups = builder.comment("Create backups, even if nobody is online")
                 .define("noPlayerBackups", false);
+        noPlayerBackupCount = builder.comment("How many backups should be created after the last player left? Set to 0 to disable.")
+                .defineInRange("noPlayerBackupCount", 1, 0, Integer.MAX_VALUE);
+        noPlayerBackupTimer = builder.comment("The time between two backups when no player is online. 0 means the same as the \"timer\" setting.")
+                .defineInRange("noPlayerBackupTimer", 0, 0, Integer.MAX_VALUE);
         createSubDirs = builder.comment("Should sub-directories be generated for each world?",
                         "Keep in mind that all configs above, including backupsToKeep and maxDiskSize, will be calculated for each sub directory.")
                 .define("createSubDirs", true);
@@ -126,9 +132,19 @@ public class CommonConfig {
         return ExperimentalConfig.isEnabled() ? ExperimentalConfig.backupChainsToKeep() : backupsToKeep.get();
     }
 
+    @Deprecated
     // converts config value from milliseconds to minutes
     public static long getTimer() {
-        return (long) timer.get() * 60 * 1000;
+        return CommonConfig.getTimer(true);
+    }
+
+    public static long getTimer(boolean arePlayersOnline) {
+        int i = noPlayerBackupTimer.get();
+        if (i == 0) {
+            i = timer.get();
+        }
+
+        return (long) (arePlayersOnline ? timer.get() : i) * 60 * 1000;
     }
 
     // converts config value from milliseconds to minutes
@@ -161,6 +177,10 @@ public class CommonConfig {
 
     public static boolean doNoPlayerBackups() {
         return noPlayerBackups.get();
+    }
+
+    public static int noPlayerBackupCount() {
+        return noPlayerBackupCount.get();
     }
 
     public static BackupType backupType() {

--- a/src/main/resources/assets/simplebackups/lang/de_de.json
+++ b/src/main/resources/assets/simplebackups/lang/de_de.json
@@ -13,6 +13,8 @@
   "simplebackups.configuration.section.simplebackups.common.experimental.toml": "Experimentelle Einstellungen",
   "simplebackups.configuration.backupChainsToKeep": "Backups-Ketten zum Behalten",
   "simplebackups.configuration.noPlayerBackups": "Backups ohne Spieler",
+  "simplebackups.configuration.noPlayerBackupCount": "Backupanzahl ohne Spieler",
+  "simplebackups.configuration.noPlayerBackupTimer": "Backup-Timer ohne Spieler",
   "simplebackups.configuration.messagesForEveryone": "Nachrichten für alle",
   "simplebackups.configuration.createSubDirs": "Unterverzeichnisse erstellen",
   "simplebackups.configuration.timer": "Timer",

--- a/src/main/resources/assets/simplebackups/lang/en_us.json
+++ b/src/main/resources/assets/simplebackups/lang/en_us.json
@@ -13,6 +13,8 @@
   "simplebackups.configuration.section.simplebackups.common.experimental.toml": "Experimental settings",
   "simplebackups.configuration.backupChainsToKeep": "Backup Chains to keep",
   "simplebackups.configuration.noPlayerBackups": "Backups without Players",
+  "simplebackups.configuration.noPlayerBackupCount": "No Player Backup Count",
+  "simplebackups.configuration.noPlayerBackupTimer": "No Player Backup Timer",
   "simplebackups.configuration.messagesForEveryone": "Messages for Everyone",
   "simplebackups.configuration.createSubDirs": "Create subdirectories",
   "simplebackups.configuration.timer": "Timer",


### PR DESCRIPTION
This pull request introduces the feature to set an amount of backups that should be created after the last player left the world - `noPlayerBackupCount`. It defaults to `1` which was the default behavior before. That means, that the next backup will still be created. After this, no backups are made unless a player joined. 
The other config option I added - `noPlayerBackupTimer` - introduces a new timer. That timer will be used if there's no player in a world. Setting it to `0` would just use the default timer `timer`. If you have `timer` set to `120`, every 2 hours a backup will be created. If you set `noPlayerBackupTimer` to `180`, it'll take 3 hours until the next backup will be created. Once a player joins between 120 and 180 minutes in this example, the backup triggers instantly.
By joining a world, the `noPlayerBackupCount` will be reset internally. So, even joining for 1s would result in starting over with a new "countdown". 

closes #59